### PR TITLE
Update fields.py

### DIFF
--- a/ldapdb/models/fields.py
+++ b/ldapdb/models/fields.py
@@ -7,7 +7,7 @@ import re
 import os
 
 from django.db.models import fields, lookups
-from django.utils import timezone
+from datetime import timezone
 
 
 class LdapLookup(lookups.Lookup):


### PR DESCRIPTION
Removing references of django.utils.timezone.utc and using datetime.timezone.utc instead. Since it was removed on django 5.0.